### PR TITLE
unhandled rejection を修正

### DIFF
--- a/firerest.js
+++ b/firerest.js
@@ -325,9 +325,10 @@
       }
 
       p.then((res) => {
-        return this.root.fire('postfetch', this, res);
-      }).catch(e => {
-        console.error('--- postfetch error ---', e);
+        this.root.fire('postfetch', this, res);
+      }).catch(() => {
+        // UnhandledRejection 回避
+        // 呼び出し側でハンドリングする為何もしない
       });
       
       return p;

--- a/firerest.js
+++ b/firerest.js
@@ -172,6 +172,8 @@
           headers: headers,
           body: data || undefined,
         });
+        // fire always
+        root.fire('always', self, apiResponse);
 
         var res = await apiResponse.json();
         if (!apiResponse.ok) {


### PR DESCRIPTION
res.ok が false のとき UnhandledRejection が発生していたのを修正

おそらく local 変数の promise で then しているのに catch していない変数が存在していると一連の処理が終わったあとに node.js が GC するタイミングでUnhandledRejectionを発生させると思われる